### PR TITLE
Fix/cli cache

### DIFF
--- a/lib/Foundation/Application.js
+++ b/lib/Foundation/Application.js
@@ -74,7 +74,6 @@ module.exports = class Application {
 	@param {Function} concrete
 	*/
 	bind(abstract,concrete){
-		var φ2;
 		
 		const key = Object.keys({[abstract]: null})[0];
 		
@@ -82,30 +81,31 @@ module.exports = class Application {
 			[key.replace(/\t/g,'').split('\r\n')]: concrete
 		});
 		
-		if (abstract.name == ConfigRepository.name) {
+		return this;
+	}
+	
+	cache(){
+		var φ2;
+		
+		settings.config = this.make(ConfigRepository);
+		Bootstrap.cache('./bootstrap/cache/config.json',this.make(ConfigRepository).all());
+		
+		// create a database.json config file.
+		
+		const dbConfig = Database.make().connection;
+		
+		dbConfig.driver = Database.client;
+		
+		if (dbConfig.driver == 'sqlite3' && dbConfig.database) {
 			
-			settings.config = this.make(ConfigRepository);
-			Bootstrap.cache('./bootstrap/cache/config.json',this.make(ConfigRepository).all());
+			dbConfig.filename = dbConfig.database;
 			
-			// create a database.json config file.
-			
-			const dbConfig = Database.make().connection;
-			
-			dbConfig.driver = Database.client;
-			
-			if (dbConfig.driver == 'sqlite3' && dbConfig.database) {
-				
-				dbConfig.filename = dbConfig.database;
-				
-				(((φ2 = dbConfig.database),delete dbConfig.database, φ2));
-			};
-			
-			Bootstrap.cache('./bootstrap/cache/database.json',{
-				'default': dbConfig
-			});
+			(((φ2 = dbConfig.database),delete dbConfig.database, φ2));
 		};
 		
-		return this;
+		return Bootstrap.cache('./bootstrap/cache/database.json',{
+			'default': dbConfig
+		});
 	}
 	
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formidablejs/framework",
-  "version": "0.0.1-rc11",
+  "version": "0.0.1-rc12",
   "description": "Formidable Framework Core",
   "author": "Donald Pakkies <donaldpakkies@gmail.com>",
   "license": "MIT",

--- a/src/Foundation/Application.imba
+++ b/src/Foundation/Application.imba
@@ -50,26 +50,26 @@ module.exports = class Application
 			[key.replace(/\t/g, '').split('\r\n')]: concrete
 		}
 
-		if abstract.name == ConfigRepository.name
-			settings.config = self.make(ConfigRepository)
-			Bootstrap.cache './bootstrap/cache/config.json', self.make(ConfigRepository).all!
-
-			# create a database.json config file.
-
-			const dbConfig = Database.make!.connection
-
-			dbConfig.driver = Database.client
-
-			if dbConfig.driver == 'sqlite3' && dbConfig.database
-				dbConfig.filename = dbConfig.database
-
-				delete dbConfig.database
-
-			Bootstrap.cache './bootstrap/cache/database.json', {
-				default: dbConfig
-			}
-
 		self
+
+	def cache
+		settings.config = self.make(ConfigRepository)
+		Bootstrap.cache './bootstrap/cache/config.json', self.make(ConfigRepository).all!
+
+		# create a database.json config file.
+
+		const dbConfig = Database.make!.connection
+
+		dbConfig.driver = Database.client
+
+		if dbConfig.driver == 'sqlite3' && dbConfig.database
+			dbConfig.filename = dbConfig.database
+
+			delete dbConfig.database
+
+		Bootstrap.cache './bootstrap/cache/database.json', {
+			default: dbConfig
+		}
 
 	def initiate kernel\Kernel, testMode\Boolean = false
 		const handler = self.make(ExceptionHandler, [self.config])

--- a/types/Foundation/Application.d.ts
+++ b/types/Foundation/Application.d.ts
@@ -21,6 +21,7 @@ declare class Application {
     @param {Function} concrete
     */
     bind(abstract: Function, concrete: Function): import("./Application");
+    cache(): void;
     /**
     @param {Kernel} kernel
     @param {Boolean} testMode


### PR DESCRIPTION
Moving application `caching` out of the application boot cycle to a custom function to prevent read only file systems from throwing an error.

> Attempts to fix: `ERROR	Error: EROFS: read-only file system, open '/var/task/bootstrap/cache/config.json'`
> Thrown by vercel