### PR TITLE
chore: update mailer minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "validatorjs": "^3.22.1"
   },
   "peerDependencies": {
-    "@formidablejs/mailer": ">=0.2.0-alpha.1",
+    "@formidablejs/mailer": ">=0.3.0",
     "@formidablejs/stubs": "0.2.x",
     "imba-shell": ">=0.4.0 <0.5.0"
   },


### PR DESCRIPTION
Bump mailer's minimum version to 0.3.0