### PR TITLE
feat: display error message if port is already in use

### DIFF
--- a/src/Foundation/Console.imba
+++ b/src/Foundation/Console.imba
@@ -87,6 +87,15 @@ export default class Console
 			instance.stdout.on 'data', do(data)
 				const line = data.toString!
 
+				if (address == null || address == undefined) && line.trim().includes('exited with error code:')
+					Output.write "\n  <bg:red> ERROR </bg:red> Development Server could not be started…\n"
+
+					Output.write "  <bg:red> ERROR </bg:red> Address in use: <u><fg:blue>http://{host || '127.0.0.1'}:{port ?? 3000}</fg:blue></u>\n"
+
+					process.exit(1)
+
+					return
+
 				if address == null || address == undefined
 					if line.includes("\x1b[1m./node_modules/@formidablejs/framework/bin/imba/server.imba") && line.includes('listening on')
 						address = line.split('listening on ')[1]

--- a/src/Foundation/Console/Commands/ServeCommand.imba
+++ b/src/Foundation/Console/Commands/ServeCommand.imba
@@ -148,11 +148,7 @@ export class ServeCommand < Command
 				delay: devDelay
 			})
 
-			process.once('SIGUSR2', do
-				gracefulShutdown(do
-					process.kill(process.pid, 'SIGUSR2')
-				)
-			)
+			process.once('SIGUSR2', do process.kill(process.pid, 'SIGUSR2'))
 
 			server.on 'stdout', do(e)
 				const data = e.toString()
@@ -163,7 +159,7 @@ export class ServeCommand < Command
 
 					self.message 'info', 'Development Server running…'
 
-					self.write "  Local: <u>{#address}</u>"
+					self.write "  Local: <u><fg:blue>{#address}</fg:blue></u>"
 
 					self.write "  <fg:yellow>Press Ctrl+C to stop the server</fg:yellow>\n"
 
@@ -172,6 +168,15 @@ export class ServeCommand < Command
 
 			server.on 'stderr', do(e)
 				const data = e.toString()
+
+				if data.trim().startsWith('Error: listen EADDRINUSE: address already in use')
+					self.message 'error', 'Development Server could not be started…', false
+
+					self.message 'error', "Address in use: <u><fg:blue>http://{data.split(' ')[7].trim()}</fg:blue></u>\n", false
+
+					process.exit(1)
+
+					return
 
 				process.stdout.write data
 


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Display error message if port is already in use (when running dev mode)
<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests.

<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
