### PR TITLE
fix: allow application to shutdown server on Ctrl+C

### DIFF
--- a/src/Foundation/Server.imba
+++ b/src/Foundation/Server.imba
@@ -38,3 +38,10 @@ export default class Server
 
 					Output.write "  <fg:yellow>Press Ctrl+C to stop the server</fg:yellow>\n"
 			)
+
+			process.on 'SIGINT', do
+				Output.write "\n  <bg:blue> INFO </bg:blue> Application Server stopped…\n"
+
+				await app.fastify!.close()
+
+				process.exit(0)


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Allow server to shutdown on SIGINT event.
<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests
<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
