### PR TITLE
chore: console log server endpoint

### DIFF
--- a/src/Http/Kernel.imba
+++ b/src/Http/Kernel.imba
@@ -1,3 +1,4 @@
+import http from 'http'
 import { writeFileSync } from 'fs-extra'
 import { join } from 'path'
 import { handleMaintenanceMode } from '../Foundation/Exceptions/Handler/handleException'
@@ -113,6 +114,7 @@ export default class Kernel
 
 			return errorHandler.beforeHandle(error, request, reply)
 
+		const schema = router.server isa http.Server ? 'http' : 'https'
 		const port = process.env.FORMIDABLE_PORT || 3000
 		const host = process.env.FORMIDABLE_HOST || '0.0.0.0'
 
@@ -124,6 +126,13 @@ export default class Kernel
 
 		if onBeforeListen
 			await onBeforeListen(port, host)
+
+		process.env.IMBA_CLUSTER = true
+
+		router.server.on 'listening', do
+			const url = "{schema}://{host == '0.0.0.0' ? 'localhost' : host}:{port}"
+
+			console.log "listening on {url}"
 
 		imba.serve router.server
 


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Output correct endpoint when running: `node craftsman serve`

Previously, the command would sometimes output: `http://::1:3000/`. This has now been fixed.

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests
<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
